### PR TITLE
added sending RTS signal

### DIFF
--- a/js/protocols/stk500.js
+++ b/js/protocols/stk500.js
@@ -158,7 +158,7 @@ STK500_protocol.prototype.initialize = function() {
     
     var upload_procedure_retry = 0;
     if (debug) console.log('Sending DTR command ...');
-    chrome.serial.setControlSignals(connectionId, {dtr: true}, function(result) {
+    chrome.serial.setControlSignals(connectionId, {dtr: true, rts: true}, function(result) {
         // connect to MCU via STK
         if (debug) console.log('Trying to get into sync with STK500');
         GUI.interval_add('firmware_upload_start', function() {

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -344,7 +344,7 @@ function onOpen(openInfo) {
             GUI.interval_remove('serial_read'); // standard connect sequence uses its own read timer
             
             // send DTR (this should reret any standard AVR mcu)
-            chrome.serial.setControlSignals(connectionId, {dtr: true}, function(result) {
+            chrome.serial.setControlSignals(connectionId, {dtr: true, rts: true}, function(result) {
                 var now = microtime();
                 var startup_message_buffer = "";
                 var startup_read_time = 0;


### PR DESCRIPTION
Some programmer boards and cables do not have DTR and instead have RTS,
this fix will allow the correct resetting of the board in those cases.
