### PR TITLE
Show 'Inverted SBUS' as a hint to the user that it's not SBUS.

### DIFF
--- a/js/data_storage.js
+++ b/js/data_storage.js
@@ -36,7 +36,7 @@ var PIN_MAP = {
     0x26: 'ANALOG',
     0x27: 'Packet loss - Beeper', // LBEEP
     0x28: 'Spektrum satellite', // spektrum satellite output
-    0x29: 'SBUS',
+    0x29: 'Inverted SBUS',
     0x2A: 'SUMD',
     0x2B: 'Link Loss Indication'
 };

--- a/tabs/tx_module.html
+++ b/tabs/tx_module.html
@@ -48,7 +48,7 @@
                     <option value="2400">2400</option>
                     <option value="1200">1200</option>
                     <option value="4">SUMD</option>
-                    <option value="3">SBUS</option>
+                    <option value="3">Inverted SBUS</option>
                     <option value="2">SPEKTRUM2048</option>
                     <option value="1">SPEKTRUM1024</option>
                 </select>


### PR DESCRIPTION
Make it clear to the user that selecting SBUS does not give you the SBUS you expect.
