### PR TITLE
Package file to build stand alon desktop application.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "openLRSng-configurator",
+  "description": "openLRSng Configurator",
+  "version": "3.8.8",
+  "main": "main.html",
+  "default_locale": "en",
+  "scripts": {
+    "start": "node_modules/gulp/bin/gulp.js build && node_modules/nw/bin/nw ."
+  },
+  "window": {
+    "title": "openLRSng Configurator",
+    "icon": "logo-openLRSng-white.png",
+    "toolbar": true,
+    "width": 1024,
+    "height": 800
+  },
+  "repository": {
+    "type": "git",
+    "url": "github.com/raul-ortega/openLRSng-configurator"
+  },
+  "author": "openLRSng",
+  "license": "GPL-3.0",
+  "dependencies": {
+    "archiver": "^2.0.3",
+    "bluebird": "3.4.1",
+    "del": "^3.0.0",
+    "gulp": "~3.9.1",
+    "gulp-concat": "~2.6.1",
+    "inflection": "1.12.0",
+    "jquery": "2.1.4",
+    "jquery-ui-npm": "1.12.0",
+    "nw": "^0.25.4-sdk",
+    "nw-builder": "^3.4.1",
+    "openlayers": "^4.3.3",
+    "run-sequence": "^2.2.0",
+    "temp": "^0.8.3",
+    "three": "0.72.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
   },
   "window": {
     "title": "openLRSng Configurator",
-    "icon": "logo-openLRSng-white.png",
+    "icon": "images/icon_128.png",
     "toolbar": true,
     "width": 1024,
     "height": 800
   },
   "repository": {
     "type": "git",
-    "url": "github.com/raul-ortega/openLRSng-configurator"
+    "url": "github.com/openLRSng/openLRSng-configurator"
   },
   "author": "openLRSng",
   "license": "GPL-3.0",


### PR DESCRIPTION
As you should know, Chrome Web Store application will support no more Windows, OS X and Linux systems. This file is needed to build the stand alone version with nw.js

Instructions to build with nw.js are here:

[https://github.com/nwjs/nw.js/wiki/How-to-package-and-distribute-your-apps](https://github.com/nwjs/nw.js/wiki/How-to-package-and-distribute-your-apps)

If you would like to test the result, I cloned the respository and bild the win32 version:

[https://github.com/raul-ortega/openLRSng-configurator/releases/tag/3.8.8](https://github.com/raul-ortega/openLRSng-configurator/releases/tag/3.8.8)

