### PR TITLE
Fix broken 'Backup all Profiles' button

### DIFF
--- a/tabs/tx_module.js
+++ b/tabs/tx_module.js
@@ -632,7 +632,7 @@ function tab_initialize_tx_module() {
 
         // backup all profiles
         $('a.backup_all_profiles').click(function () {
-            var current_profile = CONFIGURATOR.activeProfile;
+            var current_profile = CONFIGURATOR.activeProfile,
                 getting_profile = 0,
                 profile_array = [];
 


### PR DESCRIPTION
semicolon instead of comma was causing a missing 'var' declaration & breaking the 'backup all profiles' button.