### PR TITLE
add reset & reload buttons to RX edit failsafe tab

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -488,7 +488,12 @@
     "rx_failsafe_info_save_to_eeprom": {
         "message": "Save to EEPROM"
     },
-
+    "rx_failsafe_reset": {
+        "message": "Reset"
+    },
+    "rx_failsafe_reload": {
+        "message": "Reload"
+    },
     "rx_module_try_to_establish_connection": {
         "message": "Trying to establish connection with the RX module"
     },

--- a/tabs/rx_failsafe.css
+++ b/tabs/rx_failsafe.css
@@ -113,3 +113,35 @@
 .tab-RX_failsafe .back:hover {
     background-color: #dedcdc;
 }
+.tab-RX_failsafe .reset {
+    display: block;
+    position: absolute;
+    right:50%;
+    bottom: 10px;
+    height: 28px;
+    line-height: 28px;
+    padding: 0 15px 0 15px;
+    text-align: center;
+    font-weight: bold;
+    border: 1px solid silver;
+    background-color: #ececec;
+}
+.tab-RX_failsafe .reset:hover {
+    background-color: #dedcdc;
+}
+.tab-RX_failsafe .reload {
+    display: block;
+    position: absolute;
+    right:40%;
+    bottom: 10px;
+    height: 28px;
+    line-height: 28px;
+    padding: 0 15px 0 15px;
+    text-align: center;
+    font-weight: bold;
+    border: 1px solid silver;
+    background-color: #ececec;
+}
+.tab-RX_failsafe .reload:hover {
+    background-color: #dedcdc;
+}

--- a/tabs/rx_failsafe.html
+++ b/tabs/rx_failsafe.html
@@ -30,5 +30,7 @@
         </p>
     </div>
     <a class="back" href="#" i18n="rx_failsafe_back"></a>
+    <a class="reset" href="#" i18n="rx_failsafe_reset"></a>
+    <a class="reload" href="#" i18n="rx_failsafe_reload"></a>	
     <a class="save" href="#" i18n="rx_failsafe_info_save_to_eeprom"></a>
 </div>

--- a/tabs/rx_failsafe.js
+++ b/tabs/rx_failsafe.js
@@ -93,11 +93,14 @@ function tab_initialize_rx_failsafe() {
             });
         }
 
-        populate_left();
-        populate_right();
-        bind_change_events();
+        function load_UI(){
+          populate_left();
+          populate_right();
+          bind_change_events();
+          validate_bounds('input[type="number"]');
+        }
 
-        validate_bounds('input[type="number"]');
+        load_UI();
 
         var save_in_progress = false;
         $('a.save').click(function() {
@@ -148,7 +151,13 @@ function tab_initialize_rx_failsafe() {
                 GUI.log(chrome.i18n.getMessage('running_in_compatibility_mode'));
             }
         });
-
+        $('a.reset').click(function() {
+            $('div.tab-RX_failsafe .channels input[name="locked"]').prop('checked', false)
+            $('div.tab-RX_failsafe .channels input[name="enabled"]').prop('checked', false).change();
+        });
+        $('a.reload').click(function(){
+             PSP.send_message(PSP.PSP_REQ_RX_FAILSAFE, false, false, load_UI);
+        });
         $('a.back').click(tab_initialize_rx_module);
     });
 }


### PR DESCRIPTION
add 'reset' and 'reload' buttons to the RX 'edit failsafe' tab. 
- 'Reset' button will zero all values back to default, without actually saving the values (the 'Save to EEPROM' button must be pressed to commit values)
- 'Reload' button will re-request the failsafe values from the RX and reload the UI

tested, works