### PR TITLE
extend time-out for entering binary mode

### DIFF
--- a/js/serial_manager.js
+++ b/js/serial_manager.js
@@ -324,7 +324,7 @@ serial_manager.prototype.startup_listener = function(info) {
 								self.startup_cb();
 							}, 2500);
 						});
-					}, 100); 
+					}, 250); 
 				});
 			}, 10);
 			return;


### PR DESCRIPTION
fix for compatibility with older firmware that requires a longer time period before Configurator can send command to enter binary mode.

@linuxslate, can you please checkout this PR and test this?